### PR TITLE
Dockerfile fixes

### DIFF
--- a/docker-sdk/Dockerfile
+++ b/docker-sdk/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update \
 && export
 
 # Tor repository
-COPY tor.pub.asc tor.pub.asc
+ADD https://raw.githubusercontent.com/DECODEproject/decode-os/master/docker-sdk/tor.pub.asc tor.pub.asc
 RUN apt-key add tor.pub.asc
 RUN echo "deb https://deb.torproject.org/torproject.org $debian main" \
 	>> /etc/apt/sources.list
@@ -103,7 +103,8 @@ RUN apt-get --yes --force-yes purge $BUILD_DEPS \
 && apt-get --yes --force-yes --purge autoremove && apt-get clean \
 && npm cache clean --force && npm uninstall -g npm
 
-COPY supervisord.conf /etc/supervisor/supervisord.conf
+ADD https://raw.githubusercontent.com/DECODEproject/decode-os/master/docker-sdk/supervisord.conf \
+	/etc/supervisor/supervisord.conf
 RUN sed -i "s/nodaemon=true/nodaemon=$foreground/" /etc/supervisor/supervisord.conf
 
 RUN groupadd -g 6000 app && useradd -r -u 6000 -g app -d /home/app app

--- a/docker-sdk/Dockerfile
+++ b/docker-sdk/Dockerfile
@@ -27,8 +27,8 @@ ENV BUILD_DEPS="build-essential zlib1g-dev gcc make autoconf automake pkg-config
 WORKDIR /root
 
 # # debugging travis (finds gpg in local builds)
-RUN apt-get -yq update \
-&& apt-get -yq install gnupg1 ca-certificates --no-install-recommends \
+RUN apt-get update \
+&& apt-get --yes --force-yes install gnupg1 ca-certificates --no-install-recommends \
 && echo "ENVIRONMENT VARIABLES:" \
 && export
 
@@ -44,16 +44,14 @@ RUN apt-key add nodesource.gpg.key
 RUN	echo "deb https://deb.nodesource.com/node_8.x $debian main" \
 	>> /etc/apt/sources.list
 
-# && apt-get -yy update && apt-get -yy upgrade \
-
 RUN mkdir -p /usr/share/man/man1/ \
-	&& apt-get -yy update \
-	&& apt-get -yy install tor deb.torproject.org-keyring \
+	&& apt-get update \
+	&& apt-get --yes --force-yes install tor deb.torproject.org-keyring \
 	   		   	   supervisor daemontools \
 	   		   	   tmux curl redis-tools redis-server net-tools \
 				   python3 python3-stem nodejs
 
-RUN apt-get -yq install $BUILD_DEPS
+RUN apt-get --yes --force-yes install $BUILD_DEPS
 
 # Latest Zenroom built static for x86-amd64 taken from our own builds at Dyne.org
 ADD $DYNESDK/zenroom-static-amd64/lastSuccessfulBuild/artifact/src/zenroom-static /usr/bin/zenroom
@@ -97,12 +95,12 @@ ADD https://openresty.org/package/pubkey.gpg openresty.gpg
 RUN apt-key add openresty.gpg
 RUN echo "deb http://openresty.org/package/debian stretch openresty" \
 >> /etc/apt/sources.list
-RUN apt-get -yq update \
-&& apt-get -yq install --no-install-recommends openresty
+RUN apt-get update \
+&& apt-get --yes --force-yes install --no-install-recommends openresty
 
 # cleanup
-RUN apt-get -yq remove --purge $BUILD_DEPS \
-&& apt-get -yq --purge autoremove && apt-get -yq clean \
+RUN apt-get --yes --force-yes purge $BUILD_DEPS \
+&& apt-get --yes --force-yes --purge autoremove && apt-get clean \
 && npm cache clean --force && npm uninstall -g npm
 
 COPY supervisord.conf /etc/supervisor/supervisord.conf

--- a/docker-sdk/Dockerfile
+++ b/docker-sdk/Dockerfile
@@ -44,8 +44,10 @@ RUN apt-key add nodesource.gpg.key
 RUN	echo "deb https://deb.nodesource.com/node_8.x $debian main" \
 	>> /etc/apt/sources.list
 
+# && apt-get -yy update && apt-get -yy upgrade \
+
 RUN mkdir -p /usr/share/man/man1/ \
-	&& apt-get -yy update && apt-get -yy upgrade \
+	&& apt-get -yy update \
 	&& apt-get -yy install tor deb.torproject.org-keyring \
 	   		   	   supervisor daemontools \
 	   		   	   tmux curl redis-tools redis-server net-tools \


### PR DESCRIPTION
These commits were made after gathering the information on how the Dockerfile parsing works in the Devuan sdk.

The sdk did not like the short options of apt inside its chroots, so avoiding `-q` and using long options helped it to work.

This PR also replaces `COPY` instructions with `ADD`, since this functionality isn't yet implemented in the sdk/parser.